### PR TITLE
feat: Basic run executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,21 +41,33 @@ else ()
     target_compile_options(additional_config INTERFACE -O3)
 endif ()
 
+## YesChief!
+find_package(yeschief 1.1.0 REQUIRED)
+message(STATUS "Found YesChief! ${YESCHIEF_PACKAGE_VERSION}")
+message(STATUS "Included from: ${YESCHIEF_INCLUDE_DIR}")
+
+## CrossedFingers lib
 file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS crossed_fingers
-        "${PROJECT_SOURCE_DIR}/src/*.cpp"
-        "${PROJECT_SOURCE_DIR}/src/**/*.cpp"
+        "${PROJECT_SOURCE_DIR}/src/crossedfingers/*.cpp"
+        "${PROJECT_SOURCE_DIR}/src/crossedfingers/**/*.cpp"
 )
 message(DEBUG SRC_FILES=${SRC_FILES})
 
 add_library(crossed_fingers ${SRC_FILES})
+target_link_libraries(crossed_fingers PUBLIC yeschief)
 
-target_include_directories(crossed_fingers PUBLIC "${PROJECT_SOURCE_DIR}/include")
+target_include_directories(crossed_fingers PUBLIC "${PROJECT_SOURCE_DIR}/include" "${YESCHIEF_INCLUDE_DIR}")
 
 target_compile_definitions(crossed_fingers
         PUBLIC LIB_VERSION="${LIB_VERSION}"
 )
 
 target_compile_options(crossed_fingers PUBLIC -Wall)
+
+## CrossedFingers main lib
+add_library(crossed_fingers_main "${PROJECT_SOURCE_DIR}/src/main.cpp")
+target_link_libraries(crossed_fingers_main PUBLIC crossed_fingers)
+target_compile_options(crossed_fingers_main PUBLIC -Wall)
 
 # _.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-.
 # Tests

--- a/include/crossedfingers/TestRun.h
+++ b/include/crossedfingers/TestRun.h
@@ -1,4 +1,4 @@
-/**
+/*
  * MIT License
  *
  * Copyright (c) 2025-Present Kevin Traini
@@ -21,9 +21,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include <gtest/gtest.h>
-#include <my_lib.h>
+#ifndef TESTRUN_H
+#define TESTRUN_H
+/**
+ * Main class which holds TestSuites
+ */
 
-TEST(addition, itAddsInt) {
-    ASSERT_EQ(3, my_lib::addition(1, 2));
-}
+namespace crossedfingers {
+class TestRun final {
+  public:
+    static auto instance() -> TestRun &;
+
+    [[nodiscard]] auto run(int argc, char **argv) -> int;
+
+  private:
+    TestRun() = default;
+};
+} // namespace crossedfingers
+
+#endif // TESTRUN_H

--- a/include/crossedfingers/commands/RunCommand.h
+++ b/include/crossedfingers/commands/RunCommand.h
@@ -1,0 +1,47 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025-Present Kevin Traini
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef RUNCOMMAND_H
+#define RUNCOMMAND_H
+/**
+ * Main command, it runs the tests
+ */
+
+#include <yeschief.h>
+
+namespace crossedfingers {
+class RunCommand final : public yeschief::Command {
+  public:
+    [[nodiscard]] auto getName() const -> std::string override {
+        return "run";
+    }
+
+    [[nodiscard]] auto getDescription() const -> std::string override {
+        return "Run tests contained in the program";
+    }
+
+    auto run(const yeschief::CLIResults &results) -> int override;
+};
+} // namespace crossedfingers
+
+#endif // RUNCOMMAND_H

--- a/include/crossedfingers/test.h
+++ b/include/crossedfingers/test.h
@@ -1,0 +1,32 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025-Present Kevin Traini
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef TEST_H
+#define TEST_H
+/**
+ * Main header file. It includes all sub-headers
+ */
+
+#include "TestRun.h"
+
+#endif // TEST_H

--- a/shell.nix
+++ b/shell.nix
@@ -7,6 +7,7 @@ let
     hash = "sha256-S3Aoh5hplZM9QwCDawTW0CpDvHK1Lk9+k6TKYIuVkZc=";
     nodejs = pkgs.nodejs_20;
   };
+  yeschief = pkgs.callPackage ./tools/nix/yeschief.nix { };
 in
 
 pkgs.mkShellNoCC {
@@ -23,6 +24,7 @@ pkgs.mkShellNoCC {
     pkgs.nodejs_20
     pnpm
     pkgs.doxygen
+    yeschief
   ];
 
   shellHook = ''

--- a/src/crossedfingers/TestRun.cpp
+++ b/src/crossedfingers/TestRun.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * MIT License
  *
  * Copyright (c) 2025-Present Kevin Traini
@@ -21,11 +21,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef MY_LIB_H
-#define MY_LIB_H
+#include "crossedfingers/TestRun.h"
 
-namespace my_lib {
-auto addition(int a, int b) -> int;
-} // namespace my_lib
+#include "crossedfingers/commands/RunCommand.h"
 
-#endif // MY_LIB_H
+#include <iostream>
+#include <yeschief.h>
+
+using namespace crossedfingers;
+
+auto TestRun::instance() -> TestRun & {
+    static TestRun instance;
+    return instance;
+}
+
+auto TestRun::run(const int argc, char **argv) -> int {
+    if (argc < 1) {
+        throw std::runtime_error("Bad argument count given");
+    }
+    const auto program_name = std::string(argv[0]);
+    yeschief::CLI cli(program_name, "This program contains tests written with CrossedFingers 🤞");
+
+    RunCommand run;
+    cli.addCommand(&run);
+    yeschief::HelpCommand help(&cli);
+    cli.addCommand(&help);
+
+    const auto results = cli.run(argc, argv);
+    if (! results.has_value()) {
+        cli.help(std::cout);
+        return 1;
+    }
+
+    return run.run(yeschief::CLIResults({}));
+}

--- a/src/crossedfingers/commands/RunCommand.cpp
+++ b/src/crossedfingers/commands/RunCommand.cpp
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025-Present Kevin Traini
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "crossedfingers/commands/RunCommand.h"
+
+#include <iostream>
+
+using namespace crossedfingers;
+
+auto RunCommand::run(const yeschief::CLIResults &results) -> int {
+    std::cout << "Nothing to do for now\n";
+    return 0;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025-Present Kevin Traini
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <crossedfingers/TestRun.h>
+
+auto main(int argc, char **argv) -> int {
+    return crossedfingers::TestRun::instance().run(argc, argv);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,13 +1,3 @@
-FetchContent_Declare(
-        googletest
-        GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG 6910c9d9165801d8827d628cb72eb7ea9dd538c5 #v1.16.0
-)
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
-
-include(GoogleTest)
-
 # _.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-._.-.
 # Unit tests
 
@@ -24,8 +14,6 @@ target_include_directories(unit-tests PUBLIC
         "${PROJECT_SOURCE_DIR}/tests/unit")
 target_compile_definitions(unit-tests PUBLIC FIXTURES_PATH="${PROJECT_SOURCE_DIR}/tests/unit/Fixtures")
 
-target_link_libraries(unit-tests PRIVATE gtest_main gtest gmock crossed_fingers)
+target_link_libraries(unit-tests PRIVATE crossed_fingers crossed_fingers_main)
 
-gtest_discover_tests(unit-tests
-        PROPERTIES LABELS "unit"
-)
+add_test(NAME unit-tests COMMAND "unit-tests")

--- a/tests/unit/TestRunTest.cpp
+++ b/tests/unit/TestRunTest.cpp
@@ -1,0 +1,24 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025-Present Kevin Traini
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <crossedfingers/test.h>

--- a/tests/unit/commands/RunCommandTest.cpp
+++ b/tests/unit/commands/RunCommandTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * MIT License
  *
  * Copyright (c) 2025-Present Kevin Traini
@@ -21,8 +21,3 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include "my_lib.h"
-
-auto my_lib::addition(const int a, const int b) -> int {
-    return a + b;
-}

--- a/tools/bin/run_unit_tests
+++ b/tools/bin/run_unit_tests
@@ -7,4 +7,4 @@ WORKDIR="$ROOT_DIR/out/unit_tests"
 cmake -B "$WORKDIR" -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=On -DCODE_COVERAGE=On -G Ninja
 cmake --build "$WORKDIR" --target unit-tests
 cd "$WORKDIR"
-ctest -L unit --output-on-failure
+ctest --output-on-failure

--- a/tools/nix/yeschief.nix
+++ b/tools/nix/yeschief.nix
@@ -1,0 +1,19 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, ninja
+}:
+
+stdenv.mkDerivation rec {
+  pname = "yeschief";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "Gashmob";
+    repo = "YesChief";
+    rev = "v${version}";
+    hash = "sha256-Zr2J4NnIKJzLcm66S+oFSOSICL56bPLrOk/NQZyaDFA=";
+  };
+
+  nativeBuildInputs = [ cmake ninja ];
+}


### PR DESCRIPTION
Closes #6

When linking tests to `crossed_fingers` and `crossed_fingers_main` the program transform into a CrossedFingers executable with 2 commands:

- help -> display the help message
- run -> run the tests suites. In fact it does nothing for now as there is nothing to do ;)

The first lib contains all the testing framework. The second one is just a main() file and so not mandatory for the user who can just do:

    auto main(int argc, char **argv) -> int {
        return crossedfingers::TestRun::instance().run(argc, argv);
    }